### PR TITLE
Add yesPool, noPool, and resolution to prompt.js

### DIFF
--- a/packages/express-backend/models/prompt.js
+++ b/packages/express-backend/models/prompt.js
@@ -1,14 +1,17 @@
-import mongoose from 'mongoose';
+import mongoose from "mongoose";
 
 const PromptSchema = new mongoose.Schema({
   question: { type: String, required: true },
-  user: { type: mongoose.Schema.Types.ObjectId, ref: 'User', required: true },
+  user: { type: mongoose.Schema.Types.ObjectId, ref: "User", required: true },
   category: { type: String, required: true },
   numYes: { type: Number, default: 0 },
   numNo: { type: Number, default: 0 },
   dateOpened: { type: Date, required: true },
   dateClosed: { type: Date, required: true },
-  comments: [{ type: String }]
+  yesPool: { type: Number, default: 0 },
+  noPool: { type: Number, default: 0 },
+  resolution: { type: Boolean },
+  comments: [{ type: String }],
 });
 
-export default mongoose.model('Prompt', PromptSchema);
+export default mongoose.model("Prompt", PromptSchema);


### PR DESCRIPTION
I'm adding to the prompt.js backend schema.
- yesPool: the total amount of points bet on yes
- noPool: the total amount of points bet on no
- resolution: the actual answer to the prompt